### PR TITLE
ACG: Decompose client interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ The `client.go` file contains an `interface` defining the programming interface 
 
 ```golang
 type VisAdminClient interface {
-  CreateOrUpdateClient(request *CreateOrUpdateClientRequest) (CreateOrUpdateClientResponse, error)
+    CreateOrUpdateClientMethod
+}
+type CreateOrUpdateClientMethod interface {
+    CreateOrUpdateClient(request *CreateOrUpdateClientRequest) (CreateOrUpdateClientResponse, error)
 }
 ```
 

--- a/example/client.go
+++ b/example/client.go
@@ -11,11 +11,29 @@ import (
 )
 
 type TodoServiceClient interface {
+	DeleteTodosMethod
+	ListTodosMethod
+	PostTodoMethod
+	DeleteTodoMethod
+	GetTodoMethod
+	PatchTodoMethod
+}
+type DeleteTodosMethod interface {
 	DeleteTodos(request *DeleteTodosRequest) (DeleteTodosResponse, error)
+}
+type ListTodosMethod interface {
 	ListTodos(request *ListTodosRequest) (ListTodosResponse, error)
+}
+type PostTodoMethod interface {
 	PostTodo(request *PostTodoRequest) (PostTodoResponse, error)
+}
+type DeleteTodoMethod interface {
 	DeleteTodo(request *DeleteTodoRequest) (DeleteTodoResponse, error)
+}
+type GetTodoMethod interface {
 	GetTodo(request *GetTodoRequest) (GetTodoResponse, error)
+}
+type PatchTodoMethod interface {
 	PatchTodo(request *PatchTodoRequest) (PatchTodoResponse, error)
 }
 

--- a/example/framework.go
+++ b/example/framework.go
@@ -582,10 +582,10 @@ func (v *Validator) ValidateRequest(request interface{}) (*ValidationErrorsObjec
 }
 
 var (
-	GitCommit string = "0f410ab08724ac9dae51e4558de0c01638cfc8ff"
-	GitBranch string = "HEAD"
+	GitCommit string = "a6eac71c7893e75f0c294f2a5dc85bae5bfa4723"
+	GitBranch string = "feature/interface_cleanup"
 	GitTag    string = "v1.0.0"
-	BuildTime string = "Sa 6. Nov 15:03:27 CET 2021"
+	BuildTime string = "Sa 27. Nov 10:55:34 CET 2021"
 )
 
 type VersionInfo struct {

--- a/tests/api/client.go
+++ b/tests/api/client.go
@@ -13,40 +13,145 @@ import (
 )
 
 type VisAdminClient interface {
+	GetClientsMethod
+	DeleteClientMethod
+	GetClientMethod
+	CreateOrUpdateClientMethod
+	GetViewsSetsMethod
+	DeleteViewsSetMethod
+	GetViewsSetMethod
+	ActivateViewsSetMethod
+	CreateOrUpdateViewsSetMethod
+	ShowVehicleInViewMethod
+	GetPermissionsMethod
+	DestroySessionMethod
+	GetUserInfoMethod
+	CreateSessionMethod
+	GetUsersMethod
+	DeleteUserMethod
+	GetUserMethod
+	CreateOrUpdateUserMethod
+	GetBookingMethod
+	GetBookingsMethod
+	ListModelsMethod
+	GetClassesMethod
+	CodeMethod
+	DeleteCustomerSessionMethod
+	CreateCustomerSessionMethod
+	DownloadNestedFileMethod
+	DownloadImageMethod
+	ListElementsMethod
+	FileUploadMethod
+	DownloadFileMethod
+	FindByTagsMethod
+	GenericFileDownloadMethod
+	GetRentalMethod
+	GetShoesMethod
+	PostUploadMethod
+}
+type GetClientsMethod interface {
 	GetClients(request *GetClientsRequest) (GetClientsResponse, error)
+}
+type DeleteClientMethod interface {
 	DeleteClient(request *DeleteClientRequest) (DeleteClientResponse, error)
+}
+type GetClientMethod interface {
 	GetClient(request *GetClientRequest) (GetClientResponse, error)
+}
+type CreateOrUpdateClientMethod interface {
 	CreateOrUpdateClient(request *CreateOrUpdateClientRequest) (CreateOrUpdateClientResponse, error)
+}
+type GetViewsSetsMethod interface {
 	GetViewsSets(request *GetViewsSetsRequest) (GetViewsSetsResponse, error)
+}
+type DeleteViewsSetMethod interface {
 	DeleteViewsSet(request *DeleteViewsSetRequest) (DeleteViewsSetResponse, error)
+}
+type GetViewsSetMethod interface {
 	GetViewsSet(request *GetViewsSetRequest) (GetViewsSetResponse, error)
+}
+type ActivateViewsSetMethod interface {
 	ActivateViewsSet(request *ActivateViewsSetRequest) (ActivateViewsSetResponse, error)
+}
+type CreateOrUpdateViewsSetMethod interface {
 	CreateOrUpdateViewsSet(request *CreateOrUpdateViewsSetRequest) (CreateOrUpdateViewsSetResponse, error)
+}
+type ShowVehicleInViewMethod interface {
 	ShowVehicleInView(request *ShowVehicleInViewRequest) (ShowVehicleInViewResponse, error)
+}
+type GetPermissionsMethod interface {
 	GetPermissions(request *GetPermissionsRequest) (GetPermissionsResponse, error)
+}
+type DestroySessionMethod interface {
 	DestroySession(request *DestroySessionRequest) (DestroySessionResponse, error)
+}
+type GetUserInfoMethod interface {
 	GetUserInfo(request *GetUserInfoRequest) (GetUserInfoResponse, error)
+}
+type CreateSessionMethod interface {
 	CreateSession(request *CreateSessionRequest) (CreateSessionResponse, error)
+}
+type GetUsersMethod interface {
 	GetUsers(request *GetUsersRequest) (GetUsersResponse, error)
+}
+type DeleteUserMethod interface {
 	DeleteUser(request *DeleteUserRequest) (DeleteUserResponse, error)
+}
+type GetUserMethod interface {
 	GetUser(request *GetUserRequest) (GetUserResponse, error)
+}
+type CreateOrUpdateUserMethod interface {
 	CreateOrUpdateUser(request *CreateOrUpdateUserRequest) (CreateOrUpdateUserResponse, error)
+}
+type GetBookingMethod interface {
 	GetBooking(request *GetBookingRequest) (GetBookingResponse, error)
+}
+type GetBookingsMethod interface {
 	GetBookings(request *GetBookingsRequest) (GetBookingsResponse, error)
+}
+type ListModelsMethod interface {
 	ListModels(request *ListModelsRequest) (ListModelsResponse, error)
+}
+type GetClassesMethod interface {
 	GetClasses(request *GetClassesRequest) (GetClassesResponse, error)
+}
+type CodeMethod interface {
 	Code(request *CodeRequest) (CodeResponse, error)
+}
+type DeleteCustomerSessionMethod interface {
 	DeleteCustomerSession(request *DeleteCustomerSessionRequest) (DeleteCustomerSessionResponse, error)
+}
+type CreateCustomerSessionMethod interface {
 	CreateCustomerSession(request *CreateCustomerSessionRequest) (CreateCustomerSessionResponse, error)
+}
+type DownloadNestedFileMethod interface {
 	DownloadNestedFile(request *DownloadNestedFileRequest) (DownloadNestedFileResponse, error)
+}
+type DownloadImageMethod interface {
 	DownloadImage(request *DownloadImageRequest) (DownloadImageResponse, error)
+}
+type ListElementsMethod interface {
 	ListElements(request *ListElementsRequest) (ListElementsResponse, error)
+}
+type FileUploadMethod interface {
 	FileUpload(request *FileUploadRequest) (FileUploadResponse, error)
+}
+type DownloadFileMethod interface {
 	DownloadFile(request *DownloadFileRequest) (DownloadFileResponse, error)
+}
+type FindByTagsMethod interface {
 	FindByTags(request *FindByTagsRequest) (FindByTagsResponse, error)
+}
+type GenericFileDownloadMethod interface {
 	GenericFileDownload(request *GenericFileDownloadRequest) (GenericFileDownloadResponse, error)
+}
+type GetRentalMethod interface {
 	GetRental(request *GetRentalRequest) (GetRentalResponse, error)
+}
+type GetShoesMethod interface {
 	GetShoes(request *GetShoesRequest) (GetShoesResponse, error)
+}
+type PostUploadMethod interface {
 	PostUpload(request *PostUploadRequest) (PostUploadResponse, error)
 }
 

--- a/tests/api/framework.go
+++ b/tests/api/framework.go
@@ -582,10 +582,10 @@ func (v *Validator) ValidateRequest(request interface{}) (*ValidationErrorsObjec
 }
 
 var (
-	GitCommit string = "0f410ab08724ac9dae51e4558de0c01638cfc8ff"
-	GitBranch string = "HEAD"
+	GitCommit string = "5c8b2ec75cd8f17faea02dfc4bba67fe24683cb7"
+	GitBranch string = "feature/interface_cleanup"
 	GitTag    string = "v1.0.0"
-	BuildTime string = "Sa 6. Nov 15:03:27 CET 2021"
+	BuildTime string = "Sa 27. Nov 10:43:52 CET 2021"
 )
 
 type VersionInfo struct {


### PR DESCRIPTION
* Decompose client interface into smaller interfaces, fewer methods need to be satisfied.
* Can be used to make code more lean and clean, reader knows exactly which method are needed from the client.
* Allows fine granular definition of new interface types